### PR TITLE
Performance improvements, fixing exception flood

### DIFF
--- a/src/com/untamedears/ItemExchange/ItemExchangePlugin.java
+++ b/src/com/untamedears/ItemExchange/ItemExchangePlugin.java
@@ -54,6 +54,7 @@ public class ItemExchangePlugin extends JavaPlugin {
 	public static final Map<String, String> ENCHANTMENT_NAME = new HashMap<String, String>();
 	// Specifics of appeareance of ItemExchange Rules
 	public static final ItemStack ITEM_RULE_ITEMSTACK = new ItemStack(Material.STONE_BUTTON, 1);
+	public static final Material ITEM_RULE_MATERIAL = ITEM_RULE_ITEMSTACK.getType();
 
 	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 		return commandHandler.dispatch(sender, label, args);

--- a/src/com/untamedears/ItemExchange/listeners/ItemExchangeListener.java
+++ b/src/com/untamedears/ItemExchange/listeners/ItemExchangeListener.java
@@ -129,6 +129,9 @@ public class ItemExchangeListener implements Listener {
 	@EventHandler(ignoreCancelled = true)
 	public void onInventoryMove(InventoryMoveItemEvent event) {
 		ItemStack item = event.getItem();
+		if (item.getType() != ItemExchangePlugin.ITEM_RULE_MATERIAL) {
+			return;
+		}
 		
 		try {
 			ExchangeRule.parseRuleBlock(item);
@@ -152,6 +155,9 @@ public class ItemExchangeListener implements Listener {
 		}
 		
 		ItemStack item = event.getItem().getItemStack();
+		if (item.getType() != ItemExchangePlugin.ITEM_RULE_MATERIAL) {
+			return;
+		}
 		
 		try {
 			ExchangeRule.parseRuleBlock(item);


### PR DESCRIPTION
Adressing https://github.com/Civcraft/ItemExchange/issues/17

Please correct me, if I'm completly wrong here:
So as far as I understand this, we have an onInventoryPickupItem and an onInventoryMove listener, which are only there to prevent hoppers from picking up/transferring rule blocks (why even?). Every item transferred just gets parsed as an item exchange rule and if it throws an exception twice while doing that, it's assumed that the item is no exchange rule and the event is not cancelled (which means the hopper does a normal transfer). Basically this throws 2 exceptions and creates some unneccesary objects for every hopper transfer. 
The design decision behind that is kinda bad imo, if this is actually the hole eating up a ton of server performance (which doesnt seem unlikely), a simple check whether we actually have a stone button to avoid a flood of exceptions should fix this.